### PR TITLE
feat: serve index.html for default requests

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -91,6 +91,9 @@ export class OdrDatasets extends Stack {
           restrictPublicBuckets: false,
         }),
 
+        // Serve the index.html doc by default
+        websiteIndexDocument: 'index.html',
+
         // Standard CORS setup from https://s3-us-west-2.amazonaws.com/opendata.aws/pds-bucket-cf.yml
         cors: [
           {


### PR DESCRIPTION
#### Motivation

We have deployed a index.html as `s3://nz-imagery/index.html` it would be great to see this by default when browsing to `https://nz-imagery.s3.ap-southeast-2.amazonaws.com/`


#### Modification

Set `index.html` as the default object to serve.