### PR TITLE
revert: "feat: serve index.html for default requests (#3)" TDE-862

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -91,9 +91,6 @@ export class OdrDatasets extends Stack {
           restrictPublicBuckets: false,
         }),
 
-        // Serve the index.html doc by default
-        websiteIndexDocument: 'index.html',
-
         // Standard CORS setup from https://s3-us-west-2.amazonaws.com/opendata.aws/pds-bucket-cf.yml
         cors: [
           {


### PR DESCRIPTION
This reverts commit 6e507cbef3225a3c3f06c0d534b16c867a7488ca.
This is related to https://github.com/linz/imagery/pull/307
The changes haven't been applied yet.