### PR TITLE
feat: add koordinates read role TDE-946

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -140,6 +140,7 @@ export class OdrDatasets extends Stack {
 
     new CfnOutput(this, 'LogReaderArn', { value: loggingReadRole.roleArn });
   }
+
   /** Create a role that can publish new data into the open data bucket */
   setupDataManager(): void {
     const dataManagerArns = tryGetContextArns(this, 'data-manager-role-arns');


### PR DESCRIPTION
### Motivation

In order for data in nz-imagery to be used as the publishing bucket, koordinates needs read role access to the ODR buckets.

### Modification
KxReadRole create in stack and applied to ODR dataset buckets
