### PR TITLE
feat: deploy nz-coastal and nz-topography ODR buckets TDE-1456

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ The base open data registry infrastructure contains the following infrastructure
 - S3 Bucket `s3://nz-elevation` - Dataset Bucket where the elevation model open data is stored. It is publicly readable.
 - SNS Topic `nz-elevation-object_created` - AWS S3 `OBJECT_CREATED` events for the `nz-elevation` bucket are emitted from the Amazon Simple Notification Service (SNS).
 
+### Coastal Elevation
+
+- S3 Bucket `s3://nz-coastal` - Dataset Bucket where the Coastal Elevation is to be stored. It is publicly readable.
+- SNS Topic `nz-coastal-object_created` - AWS S3 `OBJECT_CREATED` events for the `nz-coastal` bucket are emitted from the Amazon Simple Notification Service (SNS).
+
+### Topography
+
+- S3 Bucket `s3://nz-topography` - Dataset Bucket where the topography vector tile open data is to be stored. It is publicly readable.
+- SNS Topic `nz-topography-object_created` - AWS S3 `OBJECT_CREATED` events for the `nz-topography` bucket are emitted from the Amazon Simple Notification Service (SNS).
+
 ### Common
 
 - S3 Bucket `s3://linz-odr-access-logs` - Log Bucket. It is where the S3 Access logs from the dataset buckets are stored.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { OdrDatasets } from './dataset.js';
 const app = new App();
 
 const env = { region: 'ap-southeast-2', account: '838278294040' };
-const datasets = ['nz-elevation', 'nz-imagery'];
+const datasets = ['nz-coastal', 'nz-elevation', 'nz-imagery', 'nz-topographic'];
 const logBucketName = 'linz-odr-access-logs';
 
 new OdrConsole(app, 'Console', { env, description: 'Cross account AWS console access' });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { OdrDatasets } from './dataset.js';
 const app = new App();
 
 const env = { region: 'ap-southeast-2', account: '838278294040' };
-const datasets = ['nz-coastal', 'nz-elevation', 'nz-imagery', 'nz-topographic'];
+const datasets = ['nz-coastal', 'nz-elevation', 'nz-imagery', 'nz-topography'];
 const logBucketName = 'linz-odr-access-logs';
 
 new OdrConsole(app, 'Console', { env, description: 'Cross account AWS console access' });


### PR DESCRIPTION
Add `nz-coastal` and `nz-topography` AWS S3 buckets to the ODR account.

In order to store incoming data for the 3D Coastal Mapping programme, and share topographic vector tiles, we want to provision new buckets for this data.

Note that the README information will be further updated once there is data in the buckets.

