### PR TITLE
feat: add LINZ AWS tags to ODR buckets TDE-1489

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@linzjs/cdk-tags": "^1.7.1",
         "@linzjs/style": "^4.2.0",
         "@types/node": "^20.4.9",
         "aws-cdk": "^2.90.0",
@@ -517,6 +518,19 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@linzjs/cdk-tags": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@linzjs/cdk-tags/-/cdk-tags-1.7.1.tgz",
+      "integrity": "sha512-nsUC4t7l/XaEJkg0+0rzpMcvyVom++MVml+7Dd3xaDK3HjnVs/99Fi01mqPo8AGBphPBQEaiv6/+UvKUJRTf6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "*",
+        "constructs": "*"
+      }
     },
     "node_modules/@linzjs/style": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "license": "ISC",
   "devDependencies": {
+    "@linzjs/cdk-tags": "^1.7.1",
     "@linzjs/style": "^4.2.0",
     "@types/node": "^20.4.9",
     "aws-cdk": "^2.90.0",

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -1,3 +1,4 @@
+import { applyTags, SecurityClassification } from '@linzjs/cdk-tags';
 import { CfnOutput, Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import { AccountPrincipal, AnyPrincipal, Effect, PolicyStatement, Role, StarPrincipal } from 'aws-cdk-lib/aws-iam';
 import { BlockPublicAccess, Bucket, BucketAccessControl, HttpMethods, StorageClass } from 'aws-cdk-lib/aws-s3';
@@ -60,7 +61,7 @@ export class OdrDatasets extends Stack {
       // 🚨 This bucket is public! 🚨
       const bucket = new Bucket(this, 'Data' + datasetTitle, {
         bucketName: datasetName,
-        // Keep older versions but expire them after 30 days incase of accidental delete.
+        // Keep older versions but expire them after 30 days in case of accidental delete.
         versioned: true,
 
         // Write the access logs into this.logBucket
@@ -101,6 +102,16 @@ export class OdrDatasets extends Stack {
             exposedHeaders: ['ETag', 'x-amz-meta-custom-header'],
           },
         ],
+      });
+
+      // add LINZ common AWS tags to bucket
+      applyTags(bucket, {
+        application: 'odr',
+        environment: 'prod',
+        group: 'li',
+        classification: SecurityClassification.Unclassified,
+        data: { isMaster: true, isPublic: true, role: 'archive' },
+        impact: 'moderate',
       });
 
       // 🚨 This makes the bucket public! 🚨


### PR DESCRIPTION
Use https://github.com/linz/cdk-tags to add common LINZ AWS tags to our Registry of Open Data buckets.

**Motivation**
Allows for central monitoring and identification of our resources, including public buckets. The tag `linz:data.is-public` will prevent public access to the ODR buckets being removed if this policy is enforced.

**Modification**
Add tags to all ODR buckets. At present all ODR buckets have the same tag requirements.