### PR TITLE
fix: retain noncurrent versions in Deep Archive TDE-1501

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -85,7 +85,7 @@ export class OdrDatasets extends Stack {
             ],
             expiredObjectDeleteMarker: true,
             // Ensure incomplete uploads are deleted
-            abortIncompleteMultipartUploadAfter: Duration.days(7),
+            abortIncompleteMultipartUploadAfter: Duration.days(3),
           },
         ],
 

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -80,7 +80,6 @@ export class OdrDatasets extends Stack {
               {
                 storageClass: StorageClass.DEEP_ARCHIVE,
                 transitionAfter: Duration.days(30),
-                noncurrentVersionsToRetain: 100,
               },
             ],
             expiredObjectDeleteMarker: true,

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -61,7 +61,7 @@ export class OdrDatasets extends Stack {
       // 🚨 This bucket is public! 🚨
       const bucket = new Bucket(this, 'Data' + datasetTitle, {
         bucketName: datasetName,
-        // Keep older versions but expire them after 30 days in case of accidental delete.
+        // Keep older versions and move them into Deep Archive after 30 days in case of accidental delete.
         versioned: true,
 
         // Write the access logs into this.logBucket
@@ -75,8 +75,14 @@ export class OdrDatasets extends Stack {
           {
             // Ensure files are in intelligent tiering access
             transitions: [{ storageClass: StorageClass.INTELLIGENT_TIERING, transitionAfter: Duration.days(0) }],
-            // Delete any old versions of files after 30 days
-            noncurrentVersionExpiration: Duration.days(30),
+            // Retain noncurrent versions in Standard for 30 days, then move to Deep Archive
+            noncurrentVersionTransitions: [
+              {
+                storageClass: StorageClass.DEEP_ARCHIVE,
+                transitionAfter: Duration.days(30),
+                noncurrentVersionsToRetain: 100,
+              },
+            ],
             expiredObjectDeleteMarker: true,
             // Ensure incomplete uploads are deleted
             abortIncompleteMultipartUploadAfter: Duration.days(7),


### PR DESCRIPTION
Currently noncurrent versions of files are deleted after 30 days.
Given that this is our authoritative source of these processed datasets, we want to retain noncurrent versions, moving them to Glacier Deep Archive after 30 days. Note that requesting a file to be restored from Deep Archive requires the `s3:RestoreObject` permission, which is not granted for public access.
Example of change:
![Screenshot from 2025-06-11 13-55-13](https://github.com/user-attachments/assets/bab6b724-7175-4bc5-97d7-ba55c4c242c2)
This change also aborts multipart uploads after 3 days down from 7 to bring these buckets in line with our other lifecycle policies.
